### PR TITLE
Feature: pass dark/light color codes for bw option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ const invert = require('invert-color');
 
 - **`color`** : `String|Array|Object`  
 Color in HEX string, RGB array or RGB object to be inverted.  
-- **`bw`** : `Boolean`  
-Optional. A boolean value indicating whether the output should be amplified to black (`#000000`) or white (`#ffffff`), according to the luminance of the original color.
+- **`bw`** : `Boolean|Object`  
+Optional. A boolean value indicating whether the output should be amplified to black (`#000000`) or white (`#ffffff`), according to the luminance of the original color.  
+When it's an object, it should be shaped like `{ dark: String?, light: String? }`,
+where `dark` and `light` are expressed as HEX strings and will be used as target
+amplified values. When any of them is missing, the default black/white will be assumed as dark/light.
 
 
 ```js
@@ -35,6 +38,9 @@ invert('#282b35')           // —> #d7d4ca
 
 // amplify to black or white
 invert('#282b35', true)     // —> #ffffff
+
+// amplify to custom dark or light color
+invert('#282b35', { dark: '#3a3a3a', light: '#fafafa' })     // —> #fafafa
 
 // input color as RGB array or object
 invert([69, 191, 189])              // —> #ba4042

--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ invert.asRgbObject('#fff')          // —> { r: 0, g: 0, b: 0 }
 
  This is useful in case, you need to create contrast (i.e. background vs foreground, for better readability). The animation at the top is a demonstration.
 
+## Contributing
+
+Clone original project (or fork and clone that):
+
+```sh
+git clone https://github.com/onury/invert-color.git
+```
+
+Install dependencies:
+
+```sh
+npm install
+```
+
+There's nothing to build. Run tests:
+
+```sh
+npm test
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const invert = require('invert-color');
 Color in HEX string, RGB array or RGB object to be inverted.  
 - **`bw`** : `Boolean|Object`  
 Optional. A boolean value indicating whether the output should be amplified to black (`#000000`) or white (`#ffffff`), according to the luminance of the original color.  
-When it's an object, it should be shaped like `{ black: String?, withe: String? }`,
+When it's an object, it should be shaped like `{ black: String?, white: String? }`,
 where `black` and `white` are expressed as HEX strings and will be used as target
 amplified values. When any of them is missing, the default black/white will be assumed.
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ const invert = require('invert-color');
 Color in HEX string, RGB array or RGB object to be inverted.  
 - **`bw`** : `Boolean|Object`  
 Optional. A boolean value indicating whether the output should be amplified to black (`#000000`) or white (`#ffffff`), according to the luminance of the original color.  
-When it's an object, it should be shaped like `{ dark: String?, light: String? }`,
-where `dark` and `light` are expressed as HEX strings and will be used as target
-amplified values. When any of them is missing, the default black/white will be assumed as dark/light.
+When it's an object, it should be shaped like `{ black: String?, withe: String? }`,
+where `black` and `white` are expressed as HEX strings and will be used as target
+amplified values. When any of them is missing, the default black/white will be assumed.
 
 
 ```js
@@ -39,8 +39,8 @@ invert('#282b35')           // —> #d7d4ca
 // amplify to black or white
 invert('#282b35', true)     // —> #ffffff
 
-// amplify to custom dark or light color
-invert('#282b35', { dark: '#3a3a3a', light: '#fafafa' })     // —> #fafafa
+// amplify to custom black or white color
+invert('#282b35', { black: '#3a3a3a', white: '#fafafa' })     // —> #fafafa
 
 // input color as RGB array or object
 invert([69, 191, 189])              // —> #ba4042

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ There's nothing to build. Run tests:
 npm test
 ```
 
+Add (failing) tests into [test/unit.spec.js](test/unit.spec.js) file.  
+Add implementation.  
+Pass tests.  
+Refactor and repeat.
+
 ## License
 
 [MIT][license].

--- a/index.js
+++ b/index.js
@@ -45,15 +45,15 @@ function getLuminance(c) {
 
 function invertToBW(color, bw, asArr) {
     const defaultColors = {
-        dark: '#000000',
-        light: '#ffffff',
+        black: '#000000',
+        white: '#ffffff',
     };
     const bwColors = (bw === true)
         ? defaultColors
         : Object.assign({}, defaultColors, bw);
     return getLuminance(color) > BW_TRESHOLD
-        ? (asArr ? hexToRGB(bwColors.dark) : bwColors.dark)
-        : (asArr ? hexToRGB(bwColors.light) : bwColors.light);
+        ? (asArr ? hexToRGB(bwColors.black) : bwColors.black)
+        : (asArr ? hexToRGB(bwColors.white) : bwColors.white);
 }
 
 function invert(color, bw) {

--- a/index.js
+++ b/index.js
@@ -44,15 +44,13 @@ function getLuminance(c) {
 }
 
 function invertToBW(color, bw, asArr) {
+    const defaultColors = {
+        dark: '#000000',
+        light: '#ffffff',
+    };
     const bwColors = (bw === true)
-        ? {
-            dark: '#000000',
-            light: '#ffffff',
-        }
-        : {
-            dark: (bw && bw.dark) || '#000000',
-            light: (bw && bw.light) || '#ffffff',
-        };
+        ? defaultColors
+        : Object.assign({}, defaultColors, bw);
     return getLuminance(color) > BW_TRESHOLD
         ? (asArr ? hexToRGB(bwColors.dark) : bwColors.dark)
         : (asArr ? hexToRGB(bwColors.light) : bwColors.light);

--- a/index.js
+++ b/index.js
@@ -43,26 +43,35 @@ function getLuminance(c) {
     return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2];
 }
 
-function invertToBW(color, asArr) {
+function invertToBW(color, bw, asArr) {
+    const bwColors = (bw === true)
+        ? {
+            dark: '#000000',
+            light: '#ffffff',
+        }
+        : {
+            dark: (bw && bw.dark) || '#000000',
+            light: (bw && bw.light) || '#ffffff',
+        };
     return getLuminance(color) > BW_TRESHOLD
-        ? (asArr ? [0, 0, 0] : '#000000')
-        : (asArr ? [255, 255, 255] : '#ffffff');
+        ? (asArr ? hexToRGB(bwColors.dark) : bwColors.dark)
+        : (asArr ? hexToRGB(bwColors.light) : bwColors.light);
 }
 
 function invert(color, bw) {
     color = toRGB(color);
-    if (bw) return invertToBW(color);
+    if (bw) return invertToBW(color, bw);
     return '#' + color.map(c => padz((255 - c).toString(16))).join('');
 }
 
 invert.asRgbArray = (color, bw) => {
     color = toRGB(color);
-    return bw ? invertToBW(color, true) : color.map(c => 255 - c);
+    return bw ? invertToBW(color, bw, true) : color.map(c => 255 - c);
 };
 
 invert.asRgbObject = (color, bw) => {
     color = toRGB(color);
-    return toObj(bw ? invertToBW(color, true) : color.map(c => 255 - c));
+    return toObj(bw ? invertToBW(color, bw, true) : color.map(c => 255 - c));
 };
 
 

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -18,8 +18,8 @@ describe('test: invert-color', () => {
     const A_CUSTOM_WHITE = [250, 250, 250];
     const O_CUSTOM_WHITE = { r: 250, g: 250, b: 250 };
     const CUSTOM_BW_COLORS = {
-        dark: CUSTOM_BLACK,
-        light: CUSTOM_WHITE,
+        black: CUSTOM_BLACK,
+        white: CUSTOM_WHITE,
     };
 
     it('should invert & match photoshop inverted colors', () => {

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -127,6 +127,12 @@ describe('test: invert-color', () => {
         expect(invert('#fff', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK);
     });
 
+    it('should support true/false/object for black and white parameter', () => {
+        expect(invert('#201395', true)).toEqual('#ffffff');
+        expect(invert('#201395', false)).toEqual('#dfec6a');
+        expect(invert('#201395', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE);
+    });
+
     it('should invert to/from array/object to B/W', () => {
         // this test also checks for object mutation
 

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -11,6 +11,16 @@ describe('test: invert-color', () => {
     const A_WHITE = [255, 255, 255];
     const O_BLACK = { r: 0, g: 0, b: 0 };
     const O_WHITE = { r: 255, g: 255, b: 255 };
+    const CUSTOM_BLACK = '#303030';
+    const CUSTOM_WHITE = '#fafafa';
+    const A_CUSTOM_BLACK = [48, 48, 48];
+    const O_CUSTOM_BLACK = { r: 48, g: 48, b: 48 };
+    const A_CUSTOM_WHITE = [250, 250, 250];
+    const O_CUSTOM_WHITE = { r: 250, g: 250, b: 250 };
+    const CUSTOM_BW_COLORS = {
+        dark: CUSTOM_BLACK,
+        light: CUSTOM_WHITE,
+    };
 
     it('should invert & match photoshop inverted colors', () => {
         //            ORIGINAL            PHOTOSHOP
@@ -102,6 +112,21 @@ describe('test: invert-color', () => {
         expect(invert('#fff', true)).toEqual('#000000');
     });
 
+    it('should invert to custom black and white colors', () => {
+        expect(invert('#631746', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE);
+        expect(invert('#655c42', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE);
+        expect(invert('#166528', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE);
+        expect(invert('#4c2946', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE);
+        expect(invert('#002d26', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE);
+        expect(invert('#e71398', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK);
+        expect(invert('#3ab3af', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK);
+        expect(invert('#76ff98', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK);
+        expect(invert('#bbb962', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK);
+        expect(invert('#52838b', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK);
+        expect(invert('#000', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE);
+        expect(invert('#fff', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK);
+    });
+
     it('should invert to/from array/object to B/W', () => {
         // this test also checks for object mutation
 
@@ -126,6 +151,32 @@ describe('test: invert-color', () => {
         // object as object
         expect(invert.asRgbObject(O_BLACK, true)).toEqual(O_WHITE);
         expect(invert.asRgbObject(O_WHITE, true)).toEqual(O_BLACK);
+    });
+
+    it('should invert to/from array/object to custom B/W', () => {
+        // this test also checks for object mutation
+
+        // hex as array
+        expect(invert.asRgbArray('#631746', CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_WHITE);
+        expect(invert.asRgbArray('#655c42', CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_WHITE);
+        expect(invert.asRgbArray('#e71398', CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_BLACK);
+
+        // hex as object
+        expect(invert.asRgbObject('#4c2946', CUSTOM_BW_COLORS)).toEqual(O_CUSTOM_WHITE);
+        expect(invert.asRgbObject('#002d26', CUSTOM_BW_COLORS)).toEqual(O_CUSTOM_WHITE);
+        expect(invert.asRgbObject('#76ff98', CUSTOM_BW_COLORS)).toEqual(O_CUSTOM_BLACK);
+
+        // array as array
+        expect(invert.asRgbArray(A_WHITE, CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_BLACK);
+        expect(invert.asRgbArray(A_BLACK, CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_WHITE);
+
+        // object as array
+        expect(invert.asRgbArray(O_BLACK, CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_WHITE);
+        expect(invert.asRgbArray(O_WHITE, CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_BLACK);
+
+        // object as object
+        expect(invert.asRgbObject(O_BLACK, CUSTOM_BW_COLORS)).toEqual(O_CUSTOM_WHITE);
+        expect(invert.asRgbObject(O_WHITE, CUSTOM_BW_COLORS)).toEqual(O_CUSTOM_BLACK);
     });
 
     it('should modulo exceeding RGB comps', () => {


### PR DESCRIPTION
Side note: as this PR introduces an additional (non breaking) feature, and given semantic versioning, you might consider bumping package minor version after accepting this. So e.g. from 1.0.x to 1.1.0.

Closes #2 