### PR TITLE
Throw a nice error message when passed null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,9 @@ function hexToRGB(hex) {
 
 // c = String (hex) | Array [r, g, b] | Object {r, g, b}
 function toRGB(c) {
+    if (!c) {
+      throw new Error('Invalid color value');
+    }
     if (Array.isArray(c)) return c;
     return typeof c === 'string' ? hexToRGB(c) : [c.r, c.g, c.b];
 }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -206,6 +206,10 @@ describe('test: invert-color', () => {
         expect(() => { invert('##631746', true); }).toThrow();
     });
 
+    test('throw on other invalid color values', () => {
+      expect(() => { invert(null, true); }).toThrow('Invalid color value');
+    });
+
     test('not throw for valid hex with/out # prefix', () => {
         expect(() => { invert('123'); }).not.toThrow();
         expect(() => { invert('123456'); }).not.toThrow();


### PR DESCRIPTION
Realistically the problem is that if isRGB gets anything other than an array or string, it treats it as an object, and trying to access properties (`c.r`) on null throws an error.

I shied away from really checking the type; it's possible to pass numbers, etc.. as well as arrays or objects of the wrong shape - execution stays alive but the user might get weird results. It's only null and undefined where a fatal error will occur and it's nice to give the user an indication of why.